### PR TITLE
Add None enum

### DIFF
--- a/Modules/Interactables.cs
+++ b/Modules/Interactables.cs
@@ -28,6 +28,7 @@ namespace BetterAPI
         [Flags]
         public enum Stages : Int64
         {
+            None = 0,
             TitanicPlains = 2,
             DistantRoost = 4,
             WetlandAspect = 8,


### PR DESCRIPTION
Add a None enum to the stages list.
The reasoning for this is that Interactables.AddToStages() handles some code related to making it a network prefab.
In which case if a client has the config file set to not spawn a interactable and it prevents Interactables.AddToStages() from running this will cause issues.
With a None enum you can instead choose to not add it to any stages instead which is cleaner and only affects the host anyway.
I know i can probably just pass the number 0 to Interactables.AddToStages instead of a enum but it 'll be cleaner this way.