### PR TITLE
Add check to prevent spawning on wrong stages.

### DIFF
--- a/Modules/Interactables.cs
+++ b/Modules/Interactables.cs
@@ -116,7 +116,7 @@ namespace BetterAPI
         {
             foreach (InteractableInfo interactable in registeredInteractables)
             {
-                if (interactable.minimumCount > 0)
+                if (interactable.minimumCount > 0 && interactable.scenes.Contains(SceneManager.GetActiveScene().name))
                 {
                     for (var i = 0; i < interactable.minimumCount; i++)
                     {


### PR DESCRIPTION
Add a check to the minimumCount hook to prevent the interactables from spawning on stages which they were not told to spawn on.
Currently they spawn on every stage if minimumCount is set which is unwanted behavior.